### PR TITLE
Make sitekey readable in backend

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,7 +21,7 @@
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>General</label>
-                <field id="sitekey" translate="label" type="password" sortOrder="10" showInDefault="1"
+                <field id="sitekey" translate="label" type="text" sortOrder="10" showInDefault="1"
                        showInWebsite="1" showInStore="0">
                     <label>Friendly Captcha Site Key</label>
                 </field>


### PR DESCRIPTION
The sitekey is written into the HTML code anyway, so it is not secret at all. And it is a bit more handy to actually see the entered sitekey.