### PR TITLE
Fix API URL

### DIFF
--- a/Model/Validate.php
+++ b/Model/Validate.php
@@ -78,7 +78,7 @@ class Validate implements ValidateInterface
         $curl = $this->curlFactory->create();
 
         try {
-            $curl->post('https://friendlycaptcha.com/api/v1/siteverify', $parameters);
+            $curl->post('https://api.friendlycaptcha.com/api/v1/siteverify', $parameters);
             $response = $this->serializer->unserialize($curl->getBody());
 
             if ($curl->getStatus() === 200) {


### PR DESCRIPTION
See https://docs.friendlycaptcha.com/#/legacy_endpoint

I even got the following error:

> !!ACTION REQUIRED!! This endpoint is deprecated, switch to https://api.friendlycaptcha.com/api/v1/siteverify. See docs page https://docs.friendlycaptcha.com/#/legacy_endpoint. This deprecated endpoint now returns this error with a certain probability. 

So this does affect clients using this extension at the moment.