### PR TITLE
Fix potential type error

### DIFF
--- a/Model/Provider/Response/DefaultSolutionProvider.php
+++ b/Model/Provider/Response/DefaultSolutionProvider.php
@@ -34,6 +34,6 @@ class DefaultSolutionProvider implements SolutionProviderInterface
      */
     public function execute(): string
     {
-        return $this->request->getParam(ValidateInterface::PARAM_FRIENDLY_CAPTCHA_SOLUTION);
+        return (string)$this->request->getParam(ValidateInterface::PARAM_FRIENDLY_CAPTCHA_SOLUTION);
     }
 }


### PR DESCRIPTION
If you have a form without Friendly Captcha on the page, you might get the following error at the moment:

    TypeError: Return value of IMI\FriendlyCaptcha\Model\Provider\Response\DefaultSolutionProvider::execute() must be of the type string, null returned