### PR TITLE
Comply with strict CSP rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Friendly Captcha integration for Magento2",
     "require": {
         "ext-intl": ">=1.0.0",
-        "magento/framework": "^102.0.0|^103.0.0",
+        "magento/framework": "^103.0.0",
         "magento/module-customer": "^102.0.0|^103.0.0",
         "magento/module-checkout": "^100.3.0",
         "magento/module-newsletter": "^100.3.0"

--- a/view/frontend/templates/imi_friendly_captcha.phtml
+++ b/view/frontend/templates/imi_friendly_captcha.phtml
@@ -3,24 +3,29 @@
  *  Copyright © iMi digital GmbH, based on work by MageSpecialist
  *  See LICENSE for license details.
  */
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /** @var $block IMI\FriendlyCaptcha\Block\Frontend\FriendlyCaptcha */
 /** @var $escaper \Magento\Framework\Escaper */
+/** @var $secureRenderer SecureHtmlRenderer */
+
 $endpoint = $block->getPuzzleEndpoint();
+$widgetId = $block->getWidgetId();
 ?>
-<div id="<?= $block->getWidgetId() ?>"
+<div id="<?= $widgetId ?>"
      class="frc-captcha"
      data-sitekey="<?= $block->getSiteKey() ?>"
      <?php if ($endpoint !== ''): ?>data-puzzle-endpoint="<?= $escaper->escapeUrl($endpoint) ?>"<?php endif; ?>
      data-lang="<?= $block->getLang() ?>"
-     data-callback="captchaSolved_<?= $block->getWidgetId() ?>"
+     data-callback="captchaSolved_<?= $widgetId ?>"
 ></div>
-<script>
+<?php
+$scriptString = <<<SCRIPT
     'use strict';
 
     document.addEventListener('DOMContentLoaded', function () {
         function setButtonDisabled(disabled) {
-            const button = Array.from(document.getElementById('<?= /* @noEscape */ $block->getWidgetId() ?>').closest('form').elements).find(el => el.type === 'submit');
+            const button = Array.from(document.getElementById('{$widgetId}').closest('form').elements).find(el => el.type === 'submit');
             if (!button) {
                 return;
             }
@@ -29,8 +34,11 @@ $endpoint = $block->getPuzzleEndpoint();
 
         setButtonDisabled(true);
 
-        window.captchaSolved_<?= /* @noEscape */ $block->getWidgetId() ?> = function () {
+        window.captchaSolved_{$widgetId} = function () {
             setButtonDisabled(false);
         }
     });
-</script>
+    SCRIPT
+?>
+<?= /** noEscape */
+$secureRenderer->renderTag('script', [], $scriptString, false) ?>

--- a/view/frontend/templates/imi_friendly_captcha_newsletter.phtml
+++ b/view/frontend/templates/imi_friendly_captcha_newsletter.phtml
@@ -3,15 +3,24 @@
  *  Copyright © iMi digital GmbH, based on work by MageSpecialist
  *  See LICENSE for license details.
  */
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /** @var $block IMI\FriendlyCaptcha\Block\Frontend\FriendlyCaptcha */
+/** @var $secureRenderer SecureHtmlRenderer */
+
 ?>
-<script>
-    'use strict';
+<?php
+$widgetId = $block->getWidgetId();
+$scriptString = <<<SCRIPT
+ 'use strict';
 
     if (document.getElementById('newsletter-validate-detail')) {
-        document.getElementById('newsletter-validate-detail').append(document.getElementById('<?= /* @noEscape */ $block->getWidgetId() ?>'));
+        document.getElementById('newsletter-validate-detail').append(document.getElementById('{$widgetId}'));
     } else {
-        document.getElementById('<?= /* @noEscape */ $block->getWidgetId() ?>').remove();
+        document.getElementById('{$widgetId}').remove();
     }
-</script>
+SCRIPT;
+
+?>
+<?= /** noEscape */
+$secureRenderer->renderTag('script', [], $scriptString, false) ?>


### PR DESCRIPTION
Fixes https://github.com/iMi-digital/magento2-friendly-captcha/issues/43.
I had to adapt the dependencies, as `SecureHtmlRenderer` is only introduced with Magento Framework `103.0.0`
This way, the module would now only compatible with Magento 2.4.0 or higher. Hope, that is okay, as 2.3 is not supported anymore anyway.
