### PR TITLE
Update parameter types to nullable arrays

### DIFF
--- a/Plugin/GraphQl/ContactUsPlugin.php
+++ b/Plugin/GraphQl/ContactUsPlugin.php
@@ -36,8 +36,8 @@ class ContactUsPlugin
         Field $field,
         $context,
         ResolveInfo $info,
-        array $value = null,
-        array $args = null
+        ?array $value = null,
+        ?array $args = null
     ): array {
         if ($this->config->isGraphQlContactUsMutationDisabled()) {
             throw new GraphQlInputException(__('The contactUs GraphQL mutation is disabled.'));


### PR DESCRIPTION
## Fix: Explicit Nullable Type Hints in `ContactUsPlugin::aroundResolve()`

### Problem

On PHP 8.1+, the following deprecation warning is thrown at runtime:

```
Deprecated Functionality: IMI\FriendlyCaptcha\Plugin\GraphQl\ContactUsPlugin::aroundResolve():
Implicitly marking parameter $value as nullable is deprecated, the explicit nullable type
must be used instead in .../Plugin/GraphQl/ContactUsPlugin.php on line 33
```

This occurs because `$value` and `$args` are typed as `array` but default to `null`, making them *implicitly* nullable. PHP 8.1 deprecated this behaviour, and it will become a hard error in PHP 8.4.

Related issue: https://github.com/iMi-digital/magento2-friendly-captcha/issues/69

---

### Fix

Updated the method signature in `Plugin/GraphQl/ContactUsPlugin.php` to use explicit nullable types:

```php
// Before
public function aroundResolve(
    callable $proceed,
    Field $field,
    $context,
    ResolveInfo $info,
    array $value = null,
    array $args = null
)

// After
public function aroundResolve(
    callable $proceed,
    Field $field,
    $context,
    ResolveInfo $info,
    ?array $value = null,
    ?array $args = null
)
```

No functional changes — this is a type hint correction only.