### PR TITLE
Improve Composer setup for standalone development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 bin/act
+/vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,12 @@
         "magento/module-checkout": "^100.3.0",
         "magento/module-newsletter": "^100.3.0"
     },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://repo.magento.com/"
+        }
+    ],
     "authors": [
         {
             "name": "Daniel Galla",
@@ -24,6 +30,11 @@
         ],
         "psr-4": {
             "IMI\\FriendlyCaptcha\\": ""
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "magento/composer-dependency-version-audit-plugin": true
         }
     }
 }


### PR DESCRIPTION
This PR makes the module easier to install and develop in isolation by configuring the required Composer repository and ignoring generated files.

- Added the official Magento Composer repository (https://repo.magento.com/) so that magento/framework and the magento/module-* dependencies can be resolved when running composer install directly from this repo.
- Allowed the `magento/composer-dependency-version-audit-plugin plugin` under config.allow-plugins to prevent the interactive prompt during install.
- Ignored `/vendor/` and `composer.lock`, following the standard convention for Composer libraries / Magento modules (the lock file is owned by the consuming project, not by the library itself).

**Motivation**      
                                                                                                                                                                                                                                                                                                                    
Cloning the repository and running composer install previously failed with:                                                                                                                                                                                                                                       
   
> Root composer.json requires magento/framework, it could not be found in any version...                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
because the Magento packages are not hosted on Packagist.